### PR TITLE
Change some links for chronologicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ A list of augmented artists & developers using public and open-source **self-aut
 Name | Profile | Software | Public Url | API Endpoint
 -----|---------|----------|------------|--------------
 [Devine Lu Linvega](https://github.com/neauoire) | [web](https://wiki.xxiivv.com) | [Horaire](https://wiki.xxiivv.com/Horaire) | [Journal](https://wiki.xxiivv.com/Journal)
-Rutherford Craze | [web](https://craze.co.uk) | [Chronologicon](https://craze.co.uk/chronologicon)
+[Rutherford Craze](https://github.com/rutherfordcraze) | [web](https://craze.co.uk) | [Chronologicon](https://github.com/rutherfordcraze/chronologicon) | [Chronologicon](https://craze.co.uk/chronologicon)
 Alexey Botkov | [web](https://nomand.co) | [Letnice](https://github.com/nomand/Letnice) | [Letnice](https://nomand.github.io/Letnice)
 [Mika Naylor](https://github.com/autophagy) | [web](http://autophagy.io/) | [faereld](https://github.com/autophagy/faereld)


### PR DESCRIPTION
Hej!
I changed a couple of link targets, since my tracker now has a public repo.
The public URL isn't updated live at the moment, feel free to delete the link if you feel it should be.